### PR TITLE
fix: cron 任务未跑到

### DIFF
--- a/cron.go
+++ b/cron.go
@@ -207,24 +207,24 @@ func (c *Cron) run() {
 				}
 				e.Prev = e.Next
 				e.Next = e.Schedule.Next(time.Now().Local())
-				go func(e *Entry) {
+				go func(e *Entry, next time.Time) {
 					e.Job.Run()
-					if c.tight && time.Now().Local().After(e.Next) {
+					if c.tight && time.Now().Local().After(next) {
 						c.continueRun <- e
 					}
-				}(e)
+				}(e, e.Next)
 			}
 			continue
 
 		case e := <-c.continueRun:
 			e.Prev = e.Next
 			e.Next = e.Schedule.Next(time.Now().Local())
-			go func(e *Entry) {
+			go func(e *Entry, next time.Time) {
 				e.Job.Run()
-				if c.tight && time.Now().Local().After(e.Next) {
+				if c.tight && time.Now().Local().After(next) {
 					c.continueRun <- e
 				}
-			}(e)
+			}(e, e.Next)
 			continue
 
 		case newEntry := <-c.add:

--- a/cron.go
+++ b/cron.go
@@ -218,13 +218,7 @@ func (c *Cron) run() {
 
 		case e := <-c.continueRun:
 			e.Prev = e.Next
-			e.Next = e.Schedule.Next(time.Now().Local())
-			go func(e *Entry, next time.Time) {
-				e.Job.Run()
-				if c.tight && time.Now().Local().After(next) {
-					c.continueRun <- e
-				}
-			}(e, e.Next)
+			e.Next = time.Now().Local()
 			continue
 
 		case newEntry := <-c.add:

--- a/cron.go
+++ b/cron.go
@@ -197,9 +197,10 @@ func (c *Cron) run() {
 		} else {
 			effective = c.entries[0].Next
 		}
+		now := time.Now().Local()
 
 		select {
-		case now = <-time.After(effective.Sub(now)):
+		case <-time.After(effective.Sub(now)):
 			// Run every entry whose next time was less than effective time.
 			for _, e := range c.entries {
 				if e.Next.After(effective) {
@@ -247,9 +248,6 @@ func (c *Cron) run() {
 		case <-time.After(time.Second):
 			// avoid block
 		}
-
-		// 'now' should be updated after newEntry and snapshot cases.
-		now = time.Now().Local()
 	}
 }
 

--- a/cron.go
+++ b/cron.go
@@ -200,9 +200,9 @@ func (c *Cron) run() {
 
 		select {
 		case now = <-time.After(effective.Sub(now)):
-			// Run every entry whose next time was this effective time.
+			// Run every entry whose next time was less than effective time.
 			for _, e := range c.entries {
-				if e.Next != effective {
+				if e.Next.After(effective) {
 					break
 				}
 				e.Prev = e.Next

--- a/cron.go
+++ b/cron.go
@@ -206,7 +206,7 @@ func (c *Cron) run() {
 					break
 				}
 				e.Prev = e.Next
-				e.Next = e.Schedule.Next(effective)
+				e.Next = e.Schedule.Next(time.Now().Local())
 				go func(e *Entry) {
 					e.Job.Run()
 					if c.tight && time.Now().Local().After(e.Next) {

--- a/cron_test.go
+++ b/cron_test.go
@@ -2,10 +2,13 @@ package cron
 
 import (
 	"fmt"
+	"log"
 	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/test-go/testify/assert"
 )
 
 // Many tests schedule a job for every second, and then wait at most a second
@@ -202,88 +205,51 @@ func TestRunEverMsWithOneMs(t *testing.T) {
 }
 
 func TestRunEveryMs(t *testing.T) {
-	wg := &sync.WaitGroup{}
-	wg.Add(3)
-	var occupied atomic.Bool
-
+	timesc := make(chan time.Time, 5)
 	cron := New()
-	cron.tight = true
-	// expected schedule
-	// 0s: schedule 1 task
-	// 500ms: skip no task
-	// 600ms: start 2 task
-	// 1000ms: skip no task
-	// 1100ms: 3 task
-	// 1500ms: skip no task
-	s := time.Now()
+	cron.tight = false
 	cron.Schedule(Every(500*time.Millisecond), FuncJob(func() {
-		start := time.Now()
-		if occupied.Load() {
-			return
-		}
-		occupied.Store(true)
-		defer func() {
-			occupied.Store(false)
-		}()
-		time.Sleep(600 * time.Millisecond)
-		t.Logf("exec %v", time.Since(start))
-		wg.Done()
+		time.Sleep(500 * time.Millisecond)
+		timesc <- time.Now()
 	}), "test19")
 	cron.Start()
 	defer cron.Stop()
 
-	select {
-	case <-time.After(3 * ONE_SECOND):
-		t.FailNow()
-	case <-wait(wg):
-		t.Log(time.Since(s))
-		if time.Since(s) < 1800*time.Millisecond {
-			t.Errorf("time %v", time.Since(s))
-		}
+	times := []time.Time{}
+	for i := 0; i < 5; i++ {
+		t := <-timesc
+		log.Printf("exec %v", t)
+		times = append(times, t)
 	}
+
+	assert.InDelta(t, times[1].UnixMilli(), times[0].UnixMilli()+500, 2)
+	assert.InDelta(t, times[2].UnixMilli(), times[1].UnixMilli()+500, 2)
+	assert.InDelta(t, times[3].UnixMilli(), times[2].UnixMilli()+500, 2)
+	assert.InDelta(t, times[4].UnixMilli(), times[3].UnixMilli()+500, 2)
 }
 
 func TestRunTight(t *testing.T) {
-	wg := &sync.WaitGroup{}
-	wg.Add(4)
-	var occupied atomic.Bool
+	timesc := make(chan time.Time, 5)
 	cron := New()
 	cron.tight = true
-	// expected schedule
-	// 0s: schedule 1 task
-	// 1s: skip no task
-	// 1.1s: start 2 task
-	// 2s: skip no task
-	// 2.2s: 3 task
-	// 3s: skip no task
-	// 3.3s: 4 task
-	// 4s: skip no task
-	// 4.4s: finished all
-	s := time.Now()
-	cron.Schedule(Every(1*time.Second), FuncJob(func() {
-		start := time.Now()
-		if occupied.Load() {
-			return
-		}
-		occupied.Store(true)
-		defer func() {
-			occupied.Store(false)
-		}()
-		time.Sleep(1100 * time.Millisecond)
-		t.Logf("exec %v %v", time.Now(), time.Since(start))
-		wg.Done()
-	}), "test18")
+	cron.Schedule(Every(1000*time.Millisecond), FuncJob(func() {
+		time.Sleep(900 * time.Millisecond)
+		timesc <- time.Now()
+	}), "test20")
 	cron.Start()
 	defer cron.Stop()
-	select {
-	case <-time.After(6 * ONE_SECOND):
-		t.FailNow()
-	case <-wait(wg):
-		t.Log(time.Since(s))
-		if time.Since(s) < 4400*time.Millisecond {
-			t.Errorf("time %v", time.Since(s))
-		}
+
+	times := []time.Time{}
+	for i := 0; i < 5; i++ {
+		t := <-timesc
+		log.Printf("exec %v", t)
+		times = append(times, t)
 	}
+
+	assert.InDelta(t, times[1].UnixMilli(), times[0].UnixMilli()+1000, 1)
+	assert.InDelta(t, times[2].UnixMilli(), times[1].UnixMilli()+1000, 1)
+	assert.InDelta(t, times[3].UnixMilli(), times[2].UnixMilli()+1000, 1)
+	assert.InDelta(t, times[4].UnixMilli(), times[3].UnixMilli()+1000, 1)
 }
 
 func TestRunNoTight(t *testing.T) {

--- a/cron_test.go
+++ b/cron_test.go
@@ -270,7 +270,7 @@ func TestRunTight(t *testing.T) {
 			occupied.Store(false)
 		}()
 		time.Sleep(1100 * time.Millisecond)
-		t.Logf("exec %v", time.Since(start))
+		t.Logf("exec %v %v", time.Now(), time.Since(start))
 		wg.Done()
 	}), "test18")
 	cron.Start()

--- a/go.mod
+++ b/go.mod
@@ -2,9 +2,9 @@ module github.com/databendcloud/cron
 
 go 1.21.1
 
+require github.com/test-go/testify v1.1.4
+
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/test-go/testify v1.1.4 // indirect
-	golang.org/x/sync v0.7.0 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,9 @@
 module github.com/databendcloud/cron
 
 go 1.21.1
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/test-go/testify v1.1.4 // indirect
+)

--- a/go.mod
+++ b/go.mod
@@ -6,4 +6,5 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/test-go/testify v1.1.4 // indirect
+	golang.org/x/sync v0.7.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,6 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/test-go/testify v1.1.4 h1:Tf9lntrKUMHiXQ07qBScBTSA0dhYQlu83hswqelv1iE=
+github.com/test-go/testify v1.1.4/go.mod h1:rH7cfJo/47vWGdi4GPj16x3/t1xGOj2YxzmNQzk2ghU=

--- a/go.sum
+++ b/go.sum
@@ -4,3 +4,5 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/test-go/testify v1.1.4 h1:Tf9lntrKUMHiXQ07qBScBTSA0dhYQlu83hswqelv1iE=
 github.com/test-go/testify v1.1.4/go.mod h1:rH7cfJo/47vWGdi4GPj16x3/t1xGOj2YxzmNQzk2ghU=
+golang.org/x/sync v0.7.0 h1:YsImfSBoP9QPYL0xyKJPq0gcaJdG3rInoqxTWbfQu9M=
+golang.org/x/sync v0.7.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=

--- a/go.sum
+++ b/go.sum
@@ -4,5 +4,3 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/test-go/testify v1.1.4 h1:Tf9lntrKUMHiXQ07qBScBTSA0dhYQlu83hswqelv1iE=
 github.com/test-go/testify v1.1.4/go.mod h1:rH7cfJo/47vWGdi4GPj16x3/t1xGOj2YxzmNQzk2ghU=
-golang.org/x/sync v0.7.0 h1:YsImfSBoP9QPYL0xyKJPq0gcaJdG3rInoqxTWbfQu9M=
-golang.org/x/sync v0.7.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=


### PR DESCRIPTION
- e.Schedule.Next(time.Now().Local()) 替代 e.Schedule.Next(effective)，防止有任务的时间点位总是早于 Now()
- 简化 tight 执行抽象，将判断条件放在一起