### PR TITLE
Use a goroutine pool on running tasks; use locks instead of chan on api

### DIFF
--- a/cron.go
+++ b/cron.go
@@ -88,6 +88,12 @@ func WithMaxWorkers(maxWorkers int) Option {
 	}
 }
 
+func WithTight(tight bool) Option {
+	return func(c *Cron) {
+		c.tight = tight
+	}
+}
+
 // New returns a new Cron job runner.
 func New(opts ...Option) *Cron {
 	c := &Cron{
@@ -116,10 +122,6 @@ func (c *Cron) worker() {
 	for e := range c.work {
 		e.Job.Run()
 	}
-}
-
-func (c *Cron) SetTight(tight bool) {
-	c.tight = tight
 }
 
 func (c *Cron) IsTight() bool {

--- a/cron.go
+++ b/cron.go
@@ -103,7 +103,7 @@ func New(opts ...Option) *Cron {
 		continueRun: make(chan *Entry),
 		work:        make(chan func(), 2048),
 		running:     false,
-		maxWorkers:  128,
+		maxWorkers:  256,
 		runningJobs: atomic.Int64{},
 		tight:       true,
 	}

--- a/cron.go
+++ b/cron.go
@@ -101,7 +101,7 @@ func New(opts ...Option) *Cron {
 		stop:        make(chan struct{}),
 		snapshot:    make(chan entries),
 		continueRun: make(chan *Entry),
-		work:        make(chan func()),
+		work:        make(chan func(), 2048),
 		running:     false,
 		maxWorkers:  128,
 		runningJobs: atomic.Int64{},
@@ -133,6 +133,10 @@ func (c *Cron) worker() {
 
 func (c *Cron) IsTight() bool {
 	return c.tight
+}
+
+func (c *Cron) QueuingJobs() int {
+	return len(c.work)
 }
 
 func (c *Cron) RunningJobs() int {

--- a/cron.go
+++ b/cron.go
@@ -245,9 +245,8 @@ func (c *Cron) step() bool {
 	var effective time.Time
 	entries := c.sortEntries()
 	if len(entries) == 0 || entries[0].NextScheduleTime.IsZero() {
-		// If there are no entries yet, just sleep - it still handles new entries
-		// and stop requests.
-		effective = time.Now().Local().AddDate(10, 0, 0)
+		// If there are no entries yet, just sleep 1 second
+		effective = time.Now().Local().Add(1 * time.Second)
 	} else {
 		effective = entries[0].NextScheduleTime
 	}
@@ -257,9 +256,10 @@ func (c *Cron) step() bool {
 	case <-time.After(effective.Sub(now)):
 		// reload entries, since the entries might be changed during the wait.
 		entries := c.sortEntries()
+		now := time.Now().Local()
 		for _, e := range entries {
-			// run every entry whose next time was less than effective time.
-			if e.NextScheduleTime.After(effective) {
+			// run every entry whose next time was less than now.
+			if e.NextScheduleTime.After(now) {
 				return true
 			}
 			c.bounceNextScheduleTime(e.Name)

--- a/cron.go
+++ b/cron.go
@@ -255,9 +255,10 @@ func (c *Cron) step() bool {
 
 	select {
 	case <-time.After(effective.Sub(now)):
-		// Run every entry whose next time was less than effective time.
+		// reload entries, since the entries might be changed during the wait.
 		entries := c.sortEntries()
 		for _, e := range entries {
+			// run every entry whose next time was less than effective time.
 			if e.NextScheduleTime.After(effective) {
 				return true
 			}

--- a/cron.go
+++ b/cron.go
@@ -105,6 +105,7 @@ func New(opts ...Option) *Cron {
 		continueRun: make(chan *Entry),
 		work:        make(chan *Entry),
 		running:     false,
+		maxWorkers:  128,
 		tight:       true,
 	}
 	for _, opt := range opts {

--- a/cron_test.go
+++ b/cron_test.go
@@ -183,7 +183,7 @@ func TestRunEveryMs(t *testing.T) {
 	timesc := make(chan time.Time, 5)
 	cron := New()
 	cron.Schedule(Every(500*time.Millisecond), FuncJob(func() {
-		time.Sleep(500 * time.Millisecond)
+		time.Sleep(490 * time.Millisecond)
 		timesc <- time.Now()
 	}), "test19")
 	cron.Start()

--- a/cron_test.go
+++ b/cron_test.go
@@ -202,6 +202,29 @@ func TestRunEveryMs(t *testing.T) {
 	assert.InDelta(t, times[4].UnixMilli(), times[3].UnixMilli()+500, 2)
 }
 
+func TestRunEveryMsWithSleepOnBoundary(t *testing.T) {
+	timesc := make(chan time.Time, 5)
+	cron := New()
+	cron.Schedule(Every(500*time.Millisecond), FuncJob(func() {
+		time.Sleep(500 * time.Millisecond)
+		timesc <- time.Now()
+	}), "test19")
+	cron.Start()
+	defer cron.Stop()
+
+	times := []time.Time{}
+	for i := 0; i < 5; i++ {
+		t := <-timesc
+		log.Printf("exec %v", t)
+		times = append(times, t)
+	}
+
+	assert.InDelta(t, times[1].UnixMilli(), times[0].UnixMilli()+1000, 2)
+	assert.InDelta(t, times[2].UnixMilli(), times[1].UnixMilli()+1000, 2)
+	assert.InDelta(t, times[3].UnixMilli(), times[2].UnixMilli()+1000, 2)
+	assert.InDelta(t, times[4].UnixMilli(), times[3].UnixMilli()+1000, 2)
+}
+
 func TestRunTight(t *testing.T) {
 	timesc := make(chan time.Time, 5)
 	cron := New()

--- a/cron_test.go
+++ b/cron_test.go
@@ -206,7 +206,7 @@ func TestRunEveryMsWithSleepOnBoundary(t *testing.T) {
 	timesc := make(chan time.Time, 5)
 	cron := New()
 	cron.Schedule(Every(500*time.Millisecond), FuncJob(func() {
-		time.Sleep(500 * time.Millisecond)
+		time.Sleep(501 * time.Millisecond)
 		timesc <- time.Now()
 	}), "test19")
 	cron.Start()

--- a/cron_test.go
+++ b/cron_test.go
@@ -39,7 +39,7 @@ func TestStopCausesJobsToNotRun(t *testing.T) {
 	cron.AddFunc("* * * * * ?", func() { wg.Done() }, "test1", nil)
 
 	select {
-	case <-time.After(ONE_SECOND):
+	case <-time.After(1 * ONE_SECOND):
 		// No job ran!
 	case <-wait(wg):
 		t.FailNow()
@@ -58,7 +58,7 @@ func TestAddBeforeRunning(t *testing.T) {
 
 	// Give cron 2 seconds to run our job (which is always activated).
 	select {
-	case <-time.After(ONE_SECOND):
+	case <-time.After(2 * ONE_SECOND):
 		t.FailNow()
 	case <-wait(wg):
 	}
@@ -103,30 +103,6 @@ func TestSnapshotEntries(t *testing.T) {
 
 }
 
-// Test that the entries are correctly sorted.
-// Add a bunch of long-in-the-future entries, and an immediate entry, and ensure
-// that the immediate entry runs immediately.
-// Also: Test that multiple jobs run in the same instant.
-func TestMultipleEntries(t *testing.T) {
-	wg := &sync.WaitGroup{}
-	wg.Add(2)
-
-	cron := New()
-	cron.AddFunc("0 0 0 1 1 ?", func() {}, "test5", nil)
-	cron.AddFunc("* * * * * ?", func() { wg.Done() }, "test6", nil)
-	cron.AddFunc("0 0 0 31 12 ?", func() {}, "test7", nil)
-	cron.AddFunc("* * * * * ?", func() { wg.Done() }, "test8", nil)
-
-	cron.Start()
-	defer cron.Stop()
-
-	select {
-	case <-time.After(ONE_SECOND):
-		t.FailNow()
-	case <-wait(wg):
-	}
-}
-
 // Test running the same job twice.
 func TestRunningJobTwice(t *testing.T) {
 	wg := &sync.WaitGroup{}
@@ -141,7 +117,7 @@ func TestRunningJobTwice(t *testing.T) {
 	defer cron.Stop()
 
 	select {
-	case <-time.After(2 * ONE_SECOND):
+	case <-time.After(3 * ONE_SECOND):
 		t.FailNow()
 	case <-wait(wg):
 	}
@@ -243,40 +219,10 @@ func TestRunTight(t *testing.T) {
 		times = append(times, t)
 	}
 
-	assert.InDelta(t, times[1].UnixMilli(), times[0].UnixMilli()+1000, 1)
-	assert.InDelta(t, times[2].UnixMilli(), times[1].UnixMilli()+1000, 1)
-	assert.InDelta(t, times[3].UnixMilli(), times[2].UnixMilli()+1000, 1)
-	assert.InDelta(t, times[4].UnixMilli(), times[3].UnixMilli()+1000, 1)
-}
-
-func TestRunNoTight2(t *testing.T) {
-	timesc := make(chan time.Time, 5)
-	running := atomic.Bool{}
-	cron := New()
-	cron.Schedule(Every(500*time.Millisecond), FuncJob(func() {
-		if running.Load() {
-			return
-		}
-		running.Store(true)
-		defer running.Store(false)
-
-		time.Sleep(1100 * time.Millisecond)
-		timesc <- time.Now()
-	}), "test20")
-	cron.Start()
-	defer cron.Stop()
-
-	times := []time.Time{}
-	for i := 0; i < 5; i++ {
-		t := <-timesc
-		times = append(times, t)
-		log.Printf("exec %v", t.Sub(times[0]).Milliseconds())
-	}
-
-	assert.InDelta(t, times[1].UnixMilli(), times[0].UnixMilli()+1000, 1)
-	assert.InDelta(t, times[2].UnixMilli(), times[1].UnixMilli()+1500, 1)
-	assert.InDelta(t, times[3].UnixMilli(), times[2].UnixMilli()+3000, 1)
-	assert.InDelta(t, times[4].UnixMilli(), times[3].UnixMilli()+4500, 1)
+	assert.InDelta(t, times[1].UnixMilli(), times[0].UnixMilli()+1000, 2)
+	assert.InDelta(t, times[2].UnixMilli(), times[1].UnixMilli()+1000, 2)
+	assert.InDelta(t, times[3].UnixMilli(), times[2].UnixMilli()+1000, 2)
+	assert.InDelta(t, times[4].UnixMilli(), times[3].UnixMilli()+1000, 2)
 }
 
 func TestRunTight2(t *testing.T) {
@@ -303,56 +249,10 @@ func TestRunTight2(t *testing.T) {
 		log.Printf("exec %v", t.Sub(times[0]).Milliseconds())
 	}
 
-	assert.InDelta(t, times[1].UnixMilli(), times[0].UnixMilli()+1100, 5)
-	assert.InDelta(t, times[2].UnixMilli(), times[1].UnixMilli()+1100, 5)
-	assert.InDelta(t, times[3].UnixMilli(), times[2].UnixMilli()+1100, 5)
-	assert.InDelta(t, times[4].UnixMilli(), times[3].UnixMilli()+1100, 5)
-}
-
-func TestRunNoTight(t *testing.T) {
-	wg := &sync.WaitGroup{}
-	wg.Add(4)
-	var occupied atomic.Bool
-	cron := New()
-	// expected schedule
-	// 0s: schedule 1 task
-	// 1s: skip no task
-	// 2s: start 2 task
-	// 3s: skip no task
-	// 4s: 1 task finished, 3 task
-	// 3s: skip no task
-	// 6s: 1 task finished, 4 task
-	// 7s: skip no task
-	// 7.1s: finished all
-	skipTimes := 0
-	s := time.Now()
-	cron.Schedule(Every(1*time.Second), FuncJob(func() {
-		start := time.Now()
-		if occupied.Load() {
-			skipTimes++
-			return
-		}
-		occupied.Store(true)
-		defer func() {
-			occupied.Store(false)
-		}()
-		time.Sleep(1100 * time.Millisecond)
-		t.Logf("exec %v", time.Since(start))
-		wg.Done()
-	}), "test18")
-	cron.Start()
-	defer cron.Stop()
-	select {
-	case <-time.After(9 * ONE_SECOND):
-		t.FailNow()
-	case <-wait(wg):
-		if time.Since(s) < 7*time.Second {
-			t.Errorf("time %v", time.Since(s))
-		}
-		if skipTimes != 4 {
-			t.Errorf("skipTimes %v", skipTimes)
-		}
-	}
+	assert.InDelta(t, times[1].UnixMilli(), times[0].UnixMilli()+1500, 5)
+	assert.InDelta(t, times[2].UnixMilli(), times[1].UnixMilli()+1500, 5)
+	assert.InDelta(t, times[3].UnixMilli(), times[2].UnixMilli()+1500, 5)
+	assert.InDelta(t, times[4].UnixMilli(), times[3].UnixMilli()+1500, 5)
 }
 
 // Test that the cron is run in the local time zone (as opposed to UTC).
@@ -403,7 +303,7 @@ func TestJob(t *testing.T) {
 
 	select {
 	case <-time.After(ONE_SECOND):
-		t.FailNow()
+		t.Fatalf("job not run")
 	case <-wait(wg):
 	}
 

--- a/cron_test.go
+++ b/cron_test.go
@@ -175,7 +175,6 @@ func TestRunEverMsWithOneMs(t *testing.T) {
 	var occupied atomic.Bool
 
 	cron := New()
-	cron.tight = true
 	s := time.Now()
 	cron.Schedule(Every(500*time.Millisecond), FuncJob(func() {
 		start := time.Now()
@@ -207,7 +206,6 @@ func TestRunEverMsWithOneMs(t *testing.T) {
 func TestRunEveryMs(t *testing.T) {
 	timesc := make(chan time.Time, 5)
 	cron := New()
-	cron.tight = false
 	cron.Schedule(Every(500*time.Millisecond), FuncJob(func() {
 		time.Sleep(500 * time.Millisecond)
 		timesc <- time.Now()
@@ -231,7 +229,6 @@ func TestRunEveryMs(t *testing.T) {
 func TestRunTight(t *testing.T) {
 	timesc := make(chan time.Time, 5)
 	cron := New()
-	cron.tight = true
 	cron.Schedule(Every(1000*time.Millisecond), FuncJob(func() {
 		time.Sleep(900 * time.Millisecond)
 		timesc <- time.Now()
@@ -256,7 +253,6 @@ func TestRunNoTight2(t *testing.T) {
 	timesc := make(chan time.Time, 5)
 	running := atomic.Bool{}
 	cron := New()
-	cron.tight = false
 	cron.Schedule(Every(500*time.Millisecond), FuncJob(func() {
 		if running.Load() {
 			return
@@ -287,7 +283,6 @@ func TestRunTight2(t *testing.T) {
 	timesc := make(chan time.Time, 5)
 	running := atomic.Bool{}
 	cron := New()
-	cron.tight = true
 	cron.Schedule(Every(500*time.Millisecond), FuncJob(func() {
 		if running.Load() {
 			return
@@ -319,7 +314,6 @@ func TestRunNoTight(t *testing.T) {
 	wg.Add(4)
 	var occupied atomic.Bool
 	cron := New()
-	cron.tight = false
 	// expected schedule
 	// 0s: schedule 1 task
 	// 1s: skip no task

--- a/go.mod
+++ b/go.mod
@@ -7,4 +7,5 @@ require github.com/test-go/testify v1.1.4
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	golang.org/x/sync v0.9.0
 )

--- a/go.sum
+++ b/go.sum
@@ -4,3 +4,5 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/test-go/testify v1.1.4 h1:Tf9lntrKUMHiXQ07qBScBTSA0dhYQlu83hswqelv1iE=
 github.com/test-go/testify v1.1.4/go.mod h1:rH7cfJo/47vWGdi4GPj16x3/t1xGOj2YxzmNQzk2ghU=
+golang.org/x/sync v0.9.0 h1:fEo0HyrW1GIgZdpbhCRO0PkJajUS5H9IFUztCgEo2jQ=
+golang.org/x/sync v0.9.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=


### PR DESCRIPTION
- use a goroutine pool on running tasks
- use locks instead of chan on api
- use a singleflight to avoid duplicated execution